### PR TITLE
Rewriting the internals of the library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+2.0.0 - 2016-05-05
+------------------
+
+* New fluent interface, allowing for greater freedom in expressing the source of the value, how to treat the value, and extra options one can apply.
+
+
 1.0.3 - 2016-04-25
 ------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+1.0.3 - 2016-04-25
+------------------
+
+* Addressed a problem where the argument matcher would continue well beyond the argument list.  Added a test and updated others.
+
+
 1.0.2 - 2016-03-28
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ By default, the provider is configured thus:
 * `.withContext(null)` - The context for factory functions is assigned to `null` as a reasonable defaults.
 
 
-### `.asFactory()`
+### `.asFactory([args...])`
 
 Treat the retrieved value as a factory function.  This example illustrates the difference between a factory and a regular value.
 
@@ -203,6 +203,19 @@ Treat the retrieved value as a factory function.  This example illustrates the d
     // factory was executed.
     console.log(factory === 2); // true
 
+You can also pass arguments to `asFactory()` and those arguments will be looked up in the container instead of the normal resolution.
+
+    // Example illustrating overriding arguments
+    dizzy.register("input", "normal input");
+    dizzy.register("alt", "alternate input");
+    function reflect(input) {
+        return input;
+    }
+    dizzy.register("normal", reflect).asFactory();
+    console.log(dizzy.resolve("normal")); // "normal input"
+    dizzy.register("overridden", reflect).asFactory(alt);
+    console.log(dizzy.resolve("overridden")); // "alternate input"
+
 
 ### `.asInstance()`
 
@@ -225,6 +238,21 @@ Treat the retrieved value as a class function and return an instance of the clas
     dizzy.register("testClassInstance", TestClass).asInstance();
     result = dizzy.resolve("testClassInstance");
     console.log(result instanceof TestClass);  // true
+
+You can also pass arguments to `asInstance()` and those arguments will be looked up in the container instead of the normal resolution and passed to the constructor.
+
+    class TestClass {
+        constructor(thing) {
+            console.log("thing is", thing);
+        }
+    }
+
+    dizzy.register("thing", "normal thing");
+    dizzy.register("alt", "alternate thing");
+    dizzy.register("normal", TestClass).asInstance();
+    dizzy.resolve("normal");  // thing is normal thing
+    dizzy.register("overridden", TestClass).asInstance(alt);
+    dizzy.resolve("overridden");  // thing is alternate thing
 
 
 ### `.asValue()`
@@ -287,7 +315,7 @@ Retrieved the value from the container using the registered value as the key.  I
     dizzy.register("TestClass", TestClass);
 
     // Now register something that makes instances of that class
-    dizzy.register("testClassInstance", "TestClass").fromContainer().instance();
+    dizzy.register("testClassInstance", "TestClass").fromContainer().asInstance();
 
     instance = dizzy.resolve("testClassInstance");
     classFn = dizzy.resolve("TestClass");

--- a/README.md
+++ b/README.md
@@ -25,138 +25,101 @@ In order to use this library, first you must install it.
 
 Next, you write some code to create the container.  You can add a few things to the container and then start injecting!
 
-    var dizzy = require('dizzy').container();
+    // dizzy = container, Dizzy = class
+    var dizzy, Dizzy;
+
+    // Load the module
+    Dizzy = require("dizzy");
+
+    // Create the container
+    dizzy = new Dizzy();
 
     // Let's make "Hello world!" for Express.js
-    dizzy.provide('port', 8000);
-    dizzy.provide('express', require('express'));
-    dizzy.register('app', function (express, addRoutes, port) {
+    dizzy.register("port", 8000);  // Static value
+    dizzy.register("express", "express").fromModule();  // Node module
+    dizzy.register("app", function (express, addRoutes, port) {
         var app;
 
         app = express();
         addRoutes(app);
         app.listen(port, function () {
-            console.log('app listening on port', port);
+            console.log("app listening on port", port);
         });
 
         return app;
-    });
-    dizzy.provide('addRoutes', function (app) {
+    }).asFactory();  // New instance every time it is injected
+    dizzy.register("addRoutes", function (app) {
         // Note, this is not an ideal way to add routes.
         // This example is for illustrative purposes only.
-        app.get('/', function (req, res) {
-            res.send('Hello world!');
+        // A better idea is restify-router-magic.
+        app.get("/", function (req, res) {
+            res.send("Hello world!");
         });
-    });
+    });  // Provides this function
 
-    // Nothing has been made yet.  Start the app.
-    dizzy.resolve('app');
+    // Nothing has been made yet.  Start the app.  This will inject
+    // "port", "express" and "addRoutes" into the call to the "app"
+    // factory.
+    dizzy.resolve("app");
 
 
 Methods
 -------
 
 
-### `dizzy.call([argsArray], callbackFn, [contextObj])`
+### `dizzy.call(callFunction, [argsArray], [contextObj])`
 
-Call the callback function with arguments from the dependency injection system.  When using the `argsArray`, the function will be called with registered values and their names will be in `argsArray`.  When calling a function only, the function's parameters must match the name of the value to provide.
+Call `callFunction` with arguments from the dependency injection system.  When using the `argsArray`, the function will be called with registered values and their names will be in `argsArray`.  When calling a function only, the function's parameters must match the name of the value to provide.
 
 When `contextObj` is specified, this uses the designated context when calling the callback.
 
-    dizzy.provide('one', 1);
+Returns the value returned from the function.
 
-    // With the argsArray
-    dizzy.call([
-        'one'
-    ], function (someVariable) {
+    dizzy.register("one", 1);
+
+    // Uses argsArray to map the dependency injection "one" to the
+    // parameter "someVariable".
+    dizzy.call(function (someVariable) {
         console.log(someVariable);  // 1
-    });
+    }, [
+        "one"
+    ]);
 
-    // Without the argsArray but with a context specifically set to null
+    // Dizzy will inject "one" to the function automatically when you
+    // do not use an argsArray.  This example also sets the context to null.
     dizzy.call(function (one) {
         console.log(one); // 1
     }, null);
 
 
-### `dizzy.instance(key, [argsArray], classFn)`
+### `dizzy.instance(classFunction, [argsArray])`
 
-Sets up a class so an instance will be to be provided.  Shortcut method for using `dizzy.register()`.  This will create a new instance every time.  See `dizzy.singleton()` when you prefer to have the same instance supplied to every component in the system.
+Creates an instance of `classFunction`.  When `argsArray` is passed, it will inject into the constructor all of the values specified.  If `argsArray` is omitted, Dizzy will look up the parameters that the constructor needs.
 
-Returns `this`.
+Returns the newly created instance.
 
-    // Inject the argument without an argsArray
-    function Alphabet(letters) {
-        this.letters = letters;
-    }
-
-    dizzy.provide('letters', 'abcdefghijklmnopqrstuvwxyz');
-    dizzy.instance('english alphabet', Alphabet);
-    alpha = dizzy.resolve('english alphabet);
-    console.log(alpha.letters); // abcdefghijklmnopqrstuvwxyz
-
-    // Inject arguments with an argsArray
-    function Coordinates(x, y) {
-        this.x = x;
-        this.y = y;
-
-        this.distanceFromOrigin = function () {
-            return Math.sqrt(this.x * this.x + this.y * this.y);
-        };
-    }
-
-    dizzy.instance('coords', [
-        'locationX',
-        'locationY'
-    ], Coordinates);
-    dizzy.provide('locationX', 4);
-    dizzy.provide('locationY', 3);
-    c = dizzy.resolve('coords');
-    console.log(c.distanceFromOrigin()); // 5
-
-    // Difference between dizzy.singleton() and dizzy.instance().
-    function Cow() {
-        this.speak = function () {
-            console.log("Moo!");
+    class Testing {
+        constructor(val) {
+            console.log(val);
         }
     }
 
-    dizzy.instance('cow-instance', Cow);
-    dizzy.singleton('cow-singleton', Cow);
-
-    cow1 = dizzy.resolve('cow-instance');
-    cow2 = dizzy.resolve('cow-instance');
-
-    if (cow1 === cow2) {
-        throw new Error('These will always be different')
-    }
-
-    cow1 = dizzy.resolve('cow-singleton', Cow);
-    cow2 = dizzy.resolve('cow-singleton', Cow);
-
-    if (cow1 !== cow2) {
-        throw new Error('These will always be the same')
-    }
-
-This method is simply a helper shortcut to using `dizzy.register()`, and the code looks a lot like this:
-
-    dizzy.instance = function (key, argsArray, classFn) {
-        /* Detect the arguments array and make adjustments as needed.
-         * That has been omitted from this example for brevity and clarity.
-         */
-        this.register(key, argsArray, function () {
-            return new classFn();
-        });
-    };
+    dizzy.register("val", "ONE");
+    dizzy.register("two", "TWO");
+    dizzy.instance(Testing);  // Injects "val" automatically, writes "ONE".
+    dizzy.instance(Testing, [
+        "two"
+    ]);  // Injects "two" using argsArray, writes "TWO" to console.
 
 
 ### `dizzy.isRegistered(key)`
 
 Returns a boolean indicating if the key is registered or not.
 
-    dizzy.provide('day type', 'sunny');
+    dizzy.register("day type", "sunny");
 
-    if (! dizzy.isRegistered('day type')) {
-        throw new Error('The type of day was registered')
+    if (! dizzy.isRegistered("day type")) {
+        throw new Error("The type of day was registered")
     }
 
 
@@ -164,121 +127,214 @@ Returns a boolean indicating if the key is registered or not.
 
 Returns an array of all registered values.
 
-    dizzy.provide('testing', true);
+    dizzy.register("testing", true);
     list = dizzy.list();
-    console.log(list);  // [ 'testing' ]
+    console.log(list);  // [ "testing" ]
 
 
-### `dizzy.provide(key, value)`
+### `dizzy.register(key, value)`
 
-Sets a given value for a key.  No dependencies will be injected.  Returns `this`.
+Sets a given value for a key.  No dependencies will be injected.  Returns `this`.  Keys can be anything - internally a Map is used.  Values can be anything.
 
-    dizzy.provide('port', 8000);
-    dizzy.provide('add', function (a, b) {
+Returns an instance of `DizzyProvider`, which allows you define how the value is retrieved, how it is handled, and additional options.
+
+    // Register a normal value
+    dizzy.register("port", 8000);
+
+    // Register a function
+    dizzy.register("add", function (a, b) {
         return a + b;
     });
 
-This acts as a shortcut for calling `dizzy.register()`.
+    // Register a class that will have dependencies injected
+    class TestClass {}
+    dizzy.register("testClassInstance", TestClass).asInstance();
 
-    dizzy.provide = function (key, value) {
-        this.register(key, [], function () {
-            return value;
-        });
-    };
+    // Register a factory that will have dependencies injected.  We want
+    // the same value returned, so this one is also cached.
+    dizzy.register("logger", function (console) {
+        return console.log.bind(console);
+    }).asFactory().cached();
+
+For additional information, look at the `DizzyProvider` section.
 
 
-### `dizzy.register(key, [argsArray], factoryFn, [contextObj])`
+`DizzyProvider`
+---------------
 
-Sets up a function as a factory.  This will automatically inject dependencies into the factory function.
+This is responsible for supplying values when they are to be resolved by Dizzy or when they are needed for injection into a factory or instance.
 
-When `argsArray` is omitted, the function's arguments are used instead.  The variable names will be the keys sought by the dependency injection system.
+There are three phases:
 
-When `contextObj` is included, the function will be called with the given context.
+* Retrieval of the value using a `from*` function.
+* Changing the value using an `as*` function.
+* Handling additional options.
 
-Returns `this`.
+By default, the provider is configured thus:
 
-    // Set up a value to inject
-    dizzy.provide('name', 'John Doe');
+* `.fromValue()` - The value registered is not looked up elsewhere.
+* `.asValue()` - The value retrieved is unaltered.
+* `.cached(false)` - The retrieved value is not cached.
+* `.withContext(null)` - The context for factory functions is assigned to `null` as a reasonable defaults.
 
-    // Call register without an argument list.
-    dizzy.register('person1', function (name) {
-        return name;
+
+### `.asFactory()`
+
+Treat the retrieved value as a factory function.  This example illustrates the difference between a factory and a regular value.
+
+    // Just setup
+    dizzy.register("val", "some value");
+
+    // Example:  Not a factory
+    dizzy.register("notFactory", function (val) {
+        console.log(val);
+        return 1;
     });
-    result = dizzy.resolve('person1');
-    console.log(result);  // "John Doe"
+    notFactory = dizzy.resolve("notFactory");
+    console.log(notFactory instanceof Function); // true
 
-    // Same as above, but here we are explicitly citing the arguments to
-    // inject
-    dizzy.register('person2', [
-        'name'
-    ], function (x, y) {
-        // y will be undefined because it was not specified in the
-        // array of arguments.
-        return x;
-    });
-    result = dizzy.resolve('person2');
-    console.log(result);  // "John Doe"
+    // Example:  Factory function that gets called
+    dizzy.register("factory", function (val) {
+        console.log(val);
+        return 2;
+    }).asFactory();
+    factory = dizzy.resolve("factory");
+    // The above logged "some value" because it was injected and the
+    // factory was executed.
+    console.log(factory === 2); // true
 
 
-### `dizzy.resolve(key)`
+### `.asInstance()`
 
-Instantiates an object, returns a provided value or executes a factory.  This injects all dependencies as well.  Returns the result.
+Treat the retrieved value as a class function and return an instance of the class function.  The constructor is called and all dependencies are injected.
 
-    dizzy = require('dizzy').container();
-    dizzy.provide('Math', Math);
-    object = dizzy.resolve('Math');
-    console.log(typeof object.log); // function
-
-
-### `dizzy.singleton(key, [argsArray], classFn)`
-
-Sets up a class so an instance will be to be provided.  Shortcut method for using `dizzy.register()`.  This will return a single instance for all resolutions; it won't become a new instance.  If you prefer to have a new instance generated, check out `dizzy.instance()`.
-
-Returns `this`.
-
-    // Illustrate instantiation without an argsArray and
-    // behavior of the singleton method.
-    function Animal(name) {
-        this.name = name;
+    // Here's a value and a class
+    dizzy.register("count", 20")
+    class TestClass {
+        constructor(count) {
+            this.count = count;
+        }
     }
 
-    dizzy.singleton('animal', Animal);
-    dizzy.provide('name', 'Spot');
-    animal1 = dizzy.resolve('animal');
-    console.log(animal1.name);  // Spot
+    // Example:  Register the class - do not make an instance
+    dizzy.register("TestClass", TestClass);
+    result = dizzy.resolve("TestClass");
+    console.log(result === TestClass);  // true
 
-    // Notice how we change the name, but since "animal" is a singleton,
-    // this didn't update the object.
-    dizzy.provide('name', 'Rover');
-    animal2 = dizzy.resolve('animal');
-    console.log(animal1.name);  // Spot
+    // Example:  Register the class and make it return an instance
+    dizzy.register("testClassInstance", TestClass).asInstance();
+    result = dizzy.resolve("testClassInstance");
+    console.log(result instanceof TestClass);  // true
 
-    if (animal1 !== animal2) {
-        throw new Error("These will always be identical instances")
+
+### `.asValue()`
+
+Returns the retrieved value without any alteration.  This is the default behavior.  The function is provided for completeness.
+
+    // Using it as a default
+    dizzy.register("one", 1);
+
+    // I don't know why, but you could do this.
+    // The last as* function overrides the others.
+    dizzy.register("two", 2).asInstance().asFactory().asValue();
+
+
+### `.cached()`
+
+Cache the result.  This remembers the value that was provided before and ensures that the exact same value is supplied everywhere.
+
+    // You may prevent factories from running multiple times
+    var count = 0;
+    function factory() {
+        count += 1;
+        return count;
     }
 
-    // Redefine the animal singleton, this time using the argsArray.
-    dizzy.singleton('animal-with-args-array', [
-        'name'
-    ], Animal);
+    // Uncached factory
+    dizzy.register("factoryUncached", factory).asFactory();
+    console.log(dizzy.resolve("factoryUncached"));  // 1
+    console.log(dizzy.resolve("factoryUncached"));  // 2
 
-Internally, the implementation of `dizzy.singleton()` is similar to this:
+    // Cached factory
+    dizzy.register("factoryCached", factory).asFactory().cached();
+    console.log(dizzy.resolve("factoryCached"));  // 3
+    console.log(dizzy.resolve("factoryCached"));  // 3
 
-    dizzy.singleton = function (key, argsArray, classFn) {
-        var instance;
+    // You may supply individual instances or the same instance
+    class TestClass {}
 
-        /* There's some magic here to make sure the arguments are right
-         * and to detect the argument array if not specified.  It's not
-         * included in this example.
-         */
-        this.register(key, argsArray, function () {
-            if (! instance) {
-                instance = new classFn();
-            }
+    // Uncached instance
+    dizzy.register("classUncached", TestClass).asInstance();
+    uncached1 = dizzy.resolve("classUncached");
+    uncached2 = dizzy.resolve("classUncached");
+    console.log(uncached1 === uncached2); // false
 
-            return instance;
-        });
+    // Cached instance
+    dizzy.register("classCached", TestClass).asInstance().cached()
+    cached1 = dizzy.resolve("classCached");
+    cached2 = dizzy.resolve("classCached");
+    console.log(cached1 === cached2); // true
+
+
+### `.fromContainer()`
+
+Retrieved the value from the container using the registered value as the key.  It's a bit odd to do this, but this mechanism lets you register a class and then register instances of that class.
+
+    // Make a class
+    class TestClass {}
+
+    // Register the class
+    dizzy.register("TestClass", TestClass);
+
+    // Now register something that makes instances of that class
+    dizzy.register("testClassInstance", "TestClass").fromContainer().instance();
+
+    instance = dizzy.resolve("testClassInstance");
+    classFn = dizzy.resolve("TestClass");
+    console.log(instance instanceof classFn); // true
+
+
+### `.fromModule()`
+
+Retrieves the true value from node using `require()`.  You supply a module name.  Make sure it is installed via npm before you start requiring it, otherwise it just won't work.
+
+    // Register a module - this does not use require() yet
+    dizzy.register("glob", "glob").fromModule();
+
+    // Resolve the data - this calls require()
+    glob = dizzy.resolve("glob");
+
+
+### `.fromValue()`
+
+Retrieves the value directly from the container without doing any lookups.  This is the default behavior.  The function is provided for completeness.
+
+    // Using it as a default
+    dizzy.register("one", 1);
+
+    // I don't know why, but you could do this.
+    // The last from* function overrides the others.
+    dizzy.register("two", 2).fromContainer().fromModule().fromValue()
+
+
+### `.withContext()`
+
+Allows you to specify a context for a factory function.
+
+    contextObj = {
+        something: "test"
     };
+    function factoryFn() {
+        console.log(this.something);
+    }
+
+    // Using the default, null context
+    dizzy.register("factoryNullContext", factoryFn).asFactory();
+    dizzy.resolve("factoryNullContext");  // logs "undefined"
+
+    // Using the specified context
+    dizzy.register("factoryWithContext", factoryFn).asFactory().withContext(contextObj);
+    dizzy.resolve("factoryWithContext");  // logs "test"
 
 
 Future Work
@@ -294,7 +350,7 @@ The methods on the container should allow one to register a hash or a map of key
 
 Having a cache may make things faster.  Clearing the cache or clearing all registered values may make testing easier.
 
-Allowing for overrides in `dizzy.resolve()` and `dizzy.call()` would make testing easier.
+Allowing for overrides in `dizzy.resolve()` and `dizzy.call()` could make testing easier.
 
 Loading all files automatically would cut down on the amount of code.  Investigate [dependable.load()](https://github.com/Bruce17/dependable).
 

--- a/lib/dizzy-provider.js
+++ b/lib/dizzy-provider.js
@@ -1,6 +1,11 @@
 "use strict";
 
 module.exports = function () {
+    /**
+     * Responsible for providing a value to Dizzy.  When used for dependency
+     * injection, this will fetch one dependency, possibly alter it and then
+     * return it to Dizzy.
+     */
     class DizzyProvider {
         constructor(value, container) {
             this.value = value;
@@ -14,6 +19,7 @@ module.exports = function () {
          * and return the result of the function.
          *
          * @param {*} ...args Overrides auto-detection of injectables
+         * @return {this}
          */
         asFactory() {
             var args;
@@ -37,6 +43,7 @@ module.exports = function () {
          * into the constructor and return the new instance.
          *
          * @param {*} ...args Overrides auto-detection of injectables
+         * @return {this}
          */
         asInstance() {
             var args;
@@ -58,6 +65,8 @@ module.exports = function () {
         /**
          * Returns the raw value as provided from the "from*" function.
          * This is the default.
+         *
+         * @return {this}
          */
         asValue() {
             this.asFn = (val) => {
@@ -73,6 +82,7 @@ module.exports = function () {
          * Dizzy.
          *
          * @param {boolean} [newSetting=true]
+         * @return {this}
          */
         cached(newSetting) {
             var cachedValue;
@@ -100,6 +110,8 @@ module.exports = function () {
         /**
          * The stored value is a key that should be retrieved from the
          * container.
+         *
+         * @return {this}
          */
         fromContainer() {
             this.fromFn = () => {
@@ -113,6 +125,8 @@ module.exports = function () {
         /**
          * The stored value is a name of a module that should be loaded
          * through `require()`
+         *
+         * @return {this}
          */
         fromModule() {
             this.fromFn = () => {
@@ -126,6 +140,8 @@ module.exports = function () {
         /**
          * The value stored should be returned as-is.
          * This is the default.
+         *
+         * @return {this}
          */
         fromValue() {
             this.fromFn = () => {
@@ -152,6 +168,8 @@ module.exports = function () {
          * factory here.
          *
          * dizzy.register("x", factory).asFactory().withContext({...})
+         *
+         * @return {this}
          */
         withContext(context) {
             if (context === undefined) {
@@ -159,6 +177,8 @@ module.exports = function () {
             }
 
             this.context = context;
+
+            return this;
         }
     }
 

--- a/lib/dizzy-provider.js
+++ b/lib/dizzy-provider.js
@@ -1,0 +1,166 @@
+"use strict";
+
+module.exports = function () {
+    class DizzyProvider {
+        constructor(value, container) {
+            this.value = value;
+            this.container = container;
+            this.fromValue().asValue().cached(false).withContext(null);
+        }
+
+
+        /**
+         * Treat the resolved value as a factory.  Inject dependencies
+         * and return the result of the function.
+         *
+         * @param {*} ...args Overrides auto-detection of injectables
+         */
+        asFactory() {
+            var args;
+
+            if (arguments.length) {
+                args = [].slice.call(arguments);
+            } else {
+                args = null;
+            }
+
+            this.asFn = (val) => {
+                return this.container.call(val, args, this.context);
+            };
+
+            return this;
+        }
+
+
+        /**
+         * Treat the resolved value as a class function.  Inject parameters
+         * into the constructor and return the new instance.
+         *
+         * @param {*} ...args Overrides auto-detection of injectables
+         */
+        asInstance() {
+            var args;
+
+            if (arguments.length) {
+                args = [].slice.call(arguments);
+            } else {
+                args = null;
+            }
+
+            this.asFn = (val) => {
+                return this.container.instance(val, args);
+            };
+
+            return this;
+        }
+
+
+        /**
+         * Returns the raw value as provided from the "from*" function.
+         * This is the default.
+         */
+        asValue() {
+            this.asFn = (val) => {
+                return val;
+            };
+
+            return this;
+        }
+
+
+        /**
+         * Enable or disable caching of the value before providing it to
+         * Dizzy.
+         *
+         * @param {boolean} [newSetting=true]
+         */
+        cached(newSetting) {
+            var cachedValue;
+
+            if (newSetting === undefined) {
+                newSetting = true;
+            }
+
+            if (newSetting) {
+                this.provide = () => {
+                    if (cachedValue === undefined) {
+                        cachedValue = this.resolve();
+                    }
+
+                    return cachedValue;
+                };
+            } else {
+                this.provide = this.resolve;
+            }
+
+            return this;
+        }
+
+
+        /**
+         * The stored value is a key that should be retrieved from the
+         * container.
+         */
+        fromContainer() {
+            this.fromFn = () => {
+                return this.container.resolve(this.value);
+            };
+
+            return this;
+        }
+
+
+        /**
+         * The stored value is a name of a module that should be loaded
+         * through `require()`
+         */
+        fromModule() {
+            this.fromFn = () => {
+                return require(this.value);
+            };
+
+            return this;
+        }
+
+
+        /**
+         * The value stored should be returned as-is.
+         * This is the default.
+         */
+        fromValue() {
+            this.fromFn = () => {
+                return this.value;
+            };
+
+            return this;
+        }
+
+
+        /**
+         * Returns the value using the from* function and as* function.
+         *
+         * @internal
+         * @return {*}
+         */
+        resolve() {
+            return this.asFn(this.fromFn());
+        }
+
+
+        /**
+         * If the value is a factory, you can set the context for the
+         * factory here.
+         *
+         * dizzy.register("x", factory).asFactory().withContext({...})
+         */
+        withContext(context) {
+            if (context === undefined) {
+                context = null;
+            }
+
+            this.context = context;
+        }
+    }
+
+    return DizzyProvider;
+};

--- a/lib/dizzy.js
+++ b/lib/dizzy.js
@@ -16,20 +16,20 @@ function determineArgs(callable) {
     str = callable.toString().trim();
 
     // Normal function and classes
-    match = str.match(/^function.*?\(([\s\S]*?)\)/);
+    match = str.match(/^function[^(]*\(([\s\w,]*?)\)/);
 
     if (! match && str.match(/^class[\s]/)) {
         // ES6 classes
-        match = str.match(/[\s}{]constructor\s*\(([\s\S]*?)\)/);
+        match = str.match(/[\s}{]constructor\s*\(([\s\w,]*?)\)/);
     } else {
         if (! match) {
             // ES6 class methods
-            match = str.match(/\(([\s\S]*?)\)[\s]*{/);
+            match = str.match(/^[\S]*\(([\s\w,]*?)\)[\s]*{/);
         }
 
         if (! match) {
             // ES6 arrow functions with parenthesis
-            match = str.match(/\(([\s\S]*?)\)[\s]*=>/);
+            match = str.match(/^\(([\s\w,]*?)\)[\s]*=>/);
         }
 
         if (! match) {
@@ -61,9 +61,9 @@ function determineArgs(callable) {
 /**
  * Creates a new instance of an object.  This is an ES5 variant of the ES6
  * spread operator when used in something like this
- * 
+ *
  *   new ClassName(...args)
- * 
+ *
  * @param {Function} ClassFn
  * @param {Array} args
  */
@@ -127,7 +127,7 @@ class Dizzy {
             var args;
 
             args = [].slice.call(arguments);
-            
+
             return newInstance(ClassFn, args);
         });
     }

--- a/lib/dizzy.js
+++ b/lib/dizzy.js
@@ -1,271 +1,123 @@
 "use strict";
 
-/**
- * Finds the arguments for something that is callable.
- *
- * @param {Function} callable
- * @return {Array} arguments
- */
-function determineArgs(callable) {
-    var match, str;
-
-    if (typeof callable !== "function") {
-        return [];
-    }
-
-    str = callable.toString().trim();
-
-    // Normal function and classes
-    match = str.match(/^function[^(]*\(([\s\w,]*?)\)/);
-
-    if (! match && str.match(/^class[\s]/)) {
-        // ES6 classes
-        match = str.match(/[\s}{]constructor\s*\(([\s\w,]*?)\)/);
-    } else {
-        if (! match) {
-            // ES6 class methods
-            match = str.match(/^[\S]*\(([\s\w,]*?)\)[\s]*{/);
+module.exports = (Provider, util) => {
+    class Dizzy {
+        /**
+         * Initializes a new Map for the key/value pairs.
+         */
+        constructor() {
+            this.registered = new Map();
         }
 
-        if (! match) {
-            // ES6 arrow functions with parenthesis
-            match = str.match(/^\(([\s\w,]*?)\)[\s]*=>/);
-        }
 
-        if (! match) {
-            // ES6 arrow functions without parenthesis
-            match = str.match(/([^=\s]*)[\s]*=>/);
+        /**
+         * Call a function after resolving the arguments.
+         *
+         * @param {Function} callbackFn
+         * @param {(Array|null)} [argsArray] What to inject - automatically detected
+         * @param {Object} [contextObj=null]
+         * @return {*} Value from callback.
+         */
+        call(callbackFn, argsArray, contextObj) {
+            var argsResolved;
 
-            if (match && match[1] == "_") {
-                match[1] = "";
-            }
-        }
-    }
+            if (!Array.isArray(argsArray)) {
+                if (argsArray !== undefined && argsArray !== null) {
+                    contextObj = argsArray;
+                }
 
-    if (! match) {
-        return [];
-    }
-
-    match = match[1].split(",")
-        .filter((arg) => {
-            return arg;
-        })
-        .map((arg) => {
-            return arg.trim();
-        });
-
-    return match;
-}
-
-
-/**
- * Creates a new instance of an object.  This is an ES5 variant of the ES6
- * spread operator when used in something like this
- *
- *   new ClassName(...args)
- *
- * @param {Function} ClassFn
- * @param {Array} args
- */
-function newInstance(ClassFn, args) {
-    return new (Function.prototype.bind.apply(ClassFn, [
-        null
-    ].concat(args)));
-}
-
-
-class Dizzy {
-    /**
-     * Initializes a new Map for the key/value pairs.
-     */
-    constructor() {
-        this.registered = new Map();
-    }
-
-
-    /**
-     * Call a function after resolving the arguments.
-     *
-     * @param {Array} argsArray Optional
-     * @param {Function} callbackFn
-     * @param {Object} contextObj Optional
-     * @return {*} Value from callback.
-     */
-    call(argsArray, callbackFn, contextObj) {
-        var argsResolved;
-
-        if (typeof argsArray == "function") {
-            contextObj = callbackFn;
-            callbackFn = argsArray;
-            argsArray = determineArgs(callbackFn);
-        }
-
-        argsResolved = argsArray.map((requirement) => {
-            return this.resolve(requirement);
-        });
-
-        return callbackFn.apply(contextObj || null, argsResolved);
-    }
-
-
-    /**
-     * Register a factory that creates a new instance of a class
-     * with every time it gets resolved.
-     *
-     * @param {*} key
-     * @param {Array} argsArray Optional
-     * @param {Function} ClassFn
-     * @return this
-     */
-    instance(key, argsArray, ClassFn) {
-        if (typeof argsArray === "function") {
-            ClassFn = argsArray;
-            argsArray = determineArgs(ClassFn);
-        }
-
-        return this.register(key, argsArray, function () {
-            var args;
-
-            args = [].slice.call(arguments);
-
-            return newInstance(ClassFn, args);
-        });
-    }
-
-
-    /**
-     * Returns a boolean indicating if a given key has been registered or not.
-     *
-     * @param {*} key
-     * @return {boolean}
-     */
-    isRegistered(key) {
-        return this.registered.has(key);
-    }
-
-
-    /**
-     * Provide an array listing every registered key.
-     *
-     * @return {Array}
-     */
-    list() {
-        return Array.from(this.registered.keys());
-    }
-
-
-    /**
-     * Provide any value for a given key.
-     *
-     * @param {*} key
-     * @param {*} value
-     * @return this
-     */
-    provide(key, value) {
-        return this.register(key, [], () => {
-            return value;
-        });
-    }
-
-
-    /**
-     * One half of the dependency injection system.  This is what everything
-     * uses to register keys and the factory functions that generate the
-     * resulting values.
-     *
-     * @param {*} key
-     * @param {Array} argsArray Optional
-     * @param {Function} factoryFn
-     * @param {Object} contextObj Optional
-     * @return this
-     */
-    register(key, argsArray, factoryFn, contextObj) {
-        if (typeof argsArray === "function") {
-            contextObj = factoryFn;
-            factoryFn = argsArray;
-            argsArray = determineArgs(factoryFn);
-        }
-
-        this.registered.set(key, {
-            argsArray: argsArray,
-            contextObj: contextObj || null,
-            factoryFn: factoryFn
-        });
-
-        return this;
-    }
-
-
-    /**
-     * The other half of the resolver.  Given a key, go figure out and
-     * make the value.
-     *
-     * @param {*} key
-     * @return {*}
-     */
-    resolve(key) {
-        var args, meta;
-
-        meta = this.registered.get(key);
-
-        if (! meta) {
-            throw new Error("Invalid key: " + key.toString());
-        }
-
-        args = meta.argsArray.map((key) => {
-            return this.resolve(key);
-        });
-
-        return meta.factoryFn.apply(meta.contextObj, args);
-    }
-
-
-    /**
-     * Add a singleton to the dependency injection system.  This will
-     * generate one instance of the object *ever*.
-     *
-     * @param {*} key
-     * @param {Array} argsArray Optional
-     * @param {Function} ClassFn
-     * @return {Object} instance of ClassFn
-     */
-    singleton(key, argsArray, ClassFn) {
-        var cachedInstance;
-
-        if (typeof argsArray === "function") {
-            ClassFn = argsArray;
-            argsArray = determineArgs(ClassFn);
-        }
-
-        return this.register(key, argsArray, function () {
-            var args;
-
-            args = [].slice.call(arguments);
-
-            if (!cachedInstance) {
-                cachedInstance = newInstance(ClassFn, args);
+                argsArray = util.determineArgs(callbackFn);
             }
 
-            return cachedInstance;
-        });
+            argsResolved = argsArray.map((requirement) => {
+                return this.resolve(requirement);
+            });
+
+            return callbackFn.apply(contextObj || null, argsResolved);
+        }
+
+
+        /**
+         * Create an instance of a class using dependency injection
+         * for each of the constructor's arguments.
+         *
+         * @param {Array} [argsArray] What to inject - automatically detected
+         * @param {Function} ClassFn
+         * @return this
+         */
+        instance(ClassFn, argsArray) {
+            var argsResolved;
+
+            if (!Array.isArray(argsArray)) {
+                argsArray = util.determineArgs(ClassFn);
+            }
+
+            argsResolved = argsArray.map((requirement) => {
+                return this.resolve(requirement);
+            });
+
+            return util.newInstance(ClassFn, argsResolved);
+        }
+
+
+        /**
+         * Returns a boolean indicating if a given key has been registered or not.
+         *
+         * @param {*} key
+         * @return {boolean}
+         */
+        isRegistered(key) {
+            return this.registered.has(key);
+        }
+
+
+        /**
+         * Provide an array listing every registered key.
+         *
+         * @return {Array}
+         */
+        list() {
+            return Array.from(this.registered.keys());
+        }
+
+
+        /**
+         * One half of the dependency injection system.  This is what everything
+         * uses to register things to be injected.
+         *
+         * @param {*} key
+         * @param {*} value
+         * @return {Provider}
+         */
+        register(key, value) {
+            var provider;
+
+            provider = new Provider(value, this);
+            this.registered.set(key, provider);
+
+            return provider;
+        }
+
+
+        /**
+         * The other half of the resolver.  Given a key, go figure out and
+         * make the value.
+         *
+         * @param {*} key
+         * @return {*}
+         */
+        resolve(key) {
+            var provider;
+
+            provider = this.registered.get(key);
+
+            if (! provider) {
+                throw new Error("Invalid key: " + key.toString());
+            }
+
+            return provider.provide();
+        }
     }
-}
 
-module.exports = {
-    /**
-     * Create a new dependency injection container.
-     *
-     * @return {Dizzy}
-     */
-    container: function () {
-        return new Dizzy();
-    },
-
-    /**
-     * Exposes the determineArgs() function for easier testing.
-     *
-     * @param {Function}
-     * @return {Array}
-     */
-    determineArgs: determineArgs
+    return Dizzy;
 };

--- a/lib/dizzy.js
+++ b/lib/dizzy.js
@@ -1,6 +1,16 @@
 "use strict";
 
 module.exports = (Provider, util) => {
+    /**
+     * Dependency injection container.
+     *
+     * Simple usage:
+     *
+     *     dizzy.register("a", "b");  // Registers the key "a" with value "b"
+     *     dizzy.register("c", (...) => { return ...}).asFactory();
+     *
+     * See the README.md for far better documentation.
+     */
     class Dizzy {
         /**
          * Initializes a new Map for the key/value pairs.
@@ -41,8 +51,8 @@ module.exports = (Provider, util) => {
          * Create an instance of a class using dependency injection
          * for each of the constructor's arguments.
          *
-         * @param {Array} [argsArray] What to inject - automatically detected
          * @param {Function} ClassFn
+         * @param {Array} [argsArray] What to inject - automatically detected
          * @return this
          */
         instance(ClassFn, argsArray) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,5 @@
+var DizzyProvider, util;
+
+util = require("./util");
+DizzyProvider = require("./dizzy-provider")();
+module.exports = require("./dizzy")(DizzyProvider, util);

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,80 @@
+"use strict";
+
+/**
+ * Finds the arguments for something that is callable.
+ *
+ * @param {Function} callable
+ * @return {Array} arguments
+ */
+function determineArgs(callable) {
+    var match, str;
+
+    if (typeof callable !== "function") {
+        return [];
+    }
+
+    str = callable.toString().trim();
+
+    // Normal function and classes
+    match = str.match(/^function[^(]*\(([\s\w,]*?)\)/);
+
+    if (! match && str.match(/^class[\s]/)) {
+        // ES6 classes
+        match = str.match(/[\s}{]constructor\s*\(([\s\w,]*?)\)/);
+    } else {
+        if (! match) {
+            // ES6 class methods
+            match = str.match(/^[\S]*\(([\s\w,]*?)\)[\s]*{/);
+        }
+
+        if (! match) {
+            // ES6 arrow functions with parenthesis
+            match = str.match(/^\(([\s\w,]*?)\)[\s]*=>/);
+        }
+
+        if (! match) {
+            // ES6 arrow functions without parenthesis
+            match = str.match(/([^=\s]*)[\s]*=>/);
+
+            if (match && match[1] == "_") {
+                match[1] = "";
+            }
+        }
+    }
+
+    if (! match) {
+        return [];
+    }
+
+    match = match[1].split(",")
+        .filter((arg) => {
+            return arg;
+        })
+        .map((arg) => {
+            return arg.trim();
+        });
+
+    return match;
+}
+
+
+/**
+ * Creates a new instance of an object.  This is an ES5 variant of the ES6
+ * spread operator when used in something like this
+ *
+ *   new ClassName(...args)
+ *
+ * @param {Function} ClassFn
+ * @param {Array} args
+ */
+function newInstance(ClassFn, args) {
+    return new (Function.prototype.bind.apply(ClassFn, [
+        null
+    ].concat(args)));
+}
+
+
+module.exports = {
+    determineArgs: determineArgs,
+    newInstance: newInstance
+};

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
     "name": "dizzy",
-    "version": "1.0.3",
+    "version": "2.0.0",
     "description": "JavaScript dependency injection system.",
-    "main": "lib/dizzy.js",
+    "main": "lib/index.js",
     "scripts": {
         "test": "jasmine-node lib spec",
         "umd": "grep -rl '// fid-umd' lib/ --include \\*.js | xargs fid-umd",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dizzy",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "JavaScript dependency injection system.",
     "main": "lib/dizzy.js",
     "scripts": {

--- a/spec/dizzy-provider.spec.js
+++ b/spec/dizzy-provider.spec.js
@@ -1,0 +1,155 @@
+"use strict";
+
+describe("DizzyProvider", () => {
+    var containerMock, DizzyProvider, functionResult, functionTest, provider;
+
+    beforeEach(() => {
+        containerMock = jasmine.createSpyObj("container", [
+            "call",
+            "instance",
+            "resolve"
+        ]);
+        functionResult = {
+            "function result": true
+        };
+        functionTest = function (arg) {
+            if (this) {
+                this.arg = arg;
+            }
+
+            return functionResult;
+        };
+        DizzyProvider = require("../lib/dizzy-provider")();
+        provider = new DizzyProvider(functionTest, containerMock);
+    });
+    it("instantiates", () => {
+        expect(typeof provider).toBe("object");
+    });
+    describe("asFactory()", () => {
+        it("calls the function as a factory", () => {
+            provider.asFactory();
+            containerMock.call.andReturn("result from calling");
+            expect(provider.provide()).toBe("result from calling");
+            expect(containerMock.call).toHaveBeenCalledWith(functionTest, null, null);
+        });
+        it("passes overridden arguments", () => {
+            provider.asFactory("test");
+            containerMock.call.andReturn("result from calling");
+            expect(provider.provide()).toBe("result from calling");
+            expect(containerMock.call).toHaveBeenCalledWith(functionTest, [
+                "test"
+            ], null);
+        });
+    });
+    describe("asInstance()", () => {
+        it("creates an instance", () => {
+            provider.asInstance();
+            containerMock.instance.andReturn("result from instance");
+            expect(provider.provide()).toBe("result from instance");
+            expect(containerMock.instance).toHaveBeenCalledWith(functionTest, null);
+        });
+        it("uses overridden arguments", () => {
+            provider.asInstance("abcd");
+            containerMock.instance.andReturn("result from instance");
+            expect(provider.provide()).toBe("result from instance");
+            expect(containerMock.instance).toHaveBeenCalledWith(functionTest, [
+                "abcd"
+            ]);
+        });
+    });
+    describe("asValue()", () => {
+        it("is the default", () => {
+            expect(provider.provide()).toBe(functionTest);
+        });
+        it("works when used directly", () => {
+            provider.asInstance().asValue();
+            expect(provider.provide()).toBe(functionTest);
+        });
+    });
+    describe("cached()", () => {
+        function doTest(matches) {
+            var first, second;
+
+            containerMock.call.andCallFake((callback) => {
+                return callback();
+            });
+            provider.asFactory();
+            functionResult = "first result";
+            first = provider.provide();
+            functionResult = "second result";
+            second = provider.provide();
+
+            if (matches) {
+                expect(first).toEqual(second);
+            } else {
+                expect(first).not.toEqual(second);
+            }
+        }
+
+        it("is disabled by default", () => {
+            doTest(false);
+        });
+        it("may be enabled with no args", () => {
+            provider.cached();
+            doTest(true);
+        });
+        it("may be enabled with truthy value", () => {
+            provider.cached(true);
+            doTest(true);
+        });
+        it("may be disabled with falsy value", () => {
+            provider.cached().cached(false);
+            doTest(false);
+        });
+    });
+    describe("fromContainer()", () => {
+        it("looks up the value in the container", () => {
+            containerMock.resolve.andReturn("resolved");
+            provider.fromContainer();
+            expect(provider.provide()).toBe("resolved");
+            expect(containerMock.resolve).toHaveBeenCalledWith(functionTest);
+        });
+    });
+    describe("fromModule()", () => {
+        it("uses require()", () => {
+            // Need to make our own provider here in order to get
+            // a Node module name
+            provider = new DizzyProvider("fs", containerMock);
+            provider.fromModule();
+            expect(provider.provide()).toBe(require("fs"));
+        });
+    });
+    describe("fromValue()", () => {
+        it("is the default", () => {
+            expect(provider.provide()).toBe(functionTest);
+        });
+        it("works when used directly", () => {
+            provider.fromContainer().fromValue();
+            expect(provider.provide()).toBe(functionTest);
+        });
+    });
+    describe("withContext()", () => {
+        var localContext;
+
+        beforeEach(() => {
+            localContext = {
+                "my context": true
+            };
+            provider.withContext(localContext);
+        });
+        it("calls the factory without overridden args", () => {
+            provider.asFactory();
+            containerMock.call.andReturn("result from calling");
+            expect(provider.provide()).toBe("result from calling");
+            expect(containerMock.call).toHaveBeenCalledWith(functionTest, null, localContext);
+        });
+        it("calls the factory with overridden args", () => {
+            provider.asFactory("test");
+            containerMock.call.andReturn("result from calling");
+            expect(provider.provide()).toBe("result from calling");
+            expect(containerMock.call).toHaveBeenCalledWith(functionTest, [
+                "test"
+            ], localContext);
+        });
+    });
+});

--- a/spec/dizzy.spec.js
+++ b/spec/dizzy.spec.js
@@ -6,11 +6,14 @@ class es6Class {
     deconstructor(wrong) {
         return wrong;
     }
-    constructor(right) {
-        return right;
+    constructor(right, correct) {
+        return right + correct;
     }
     reconstructor(incorrect) {
         return incorrect;
+    }
+    subconstructor(wrong, bad) {
+        return wrong + bad;
     }
 }
 
@@ -70,15 +73,25 @@ describe("Dizzy's exports", () => {
             });
             it("works with new classes", () => {
                 expect(dizzy.determineArgs(es6Class)).toEqual([
-                    "right"
+                    "right",
+                    "correct"
                 ]);
             });
-            it("works with new class methods", () => {
+            it("works with new class methods that have a single argument", () => {
                 var x;
 
                 x = new es6Class();
                 expect(dizzy.determineArgs(x.reconstructor)).toEqual([
                     "incorrect"
+                ]);
+            });
+            it("works with new class methods that have multiple arguments", () => {
+                var x;
+
+                x = new es6Class();
+                expect(dizzy.determineArgs(x.subconstructor)).toEqual([
+                    "wrong",
+                    "bad"
                 ]);
             });
         });
@@ -110,6 +123,11 @@ describe("Dizzy's exports", () => {
             });
             it("handles ES6 classes without a constructor", () => {
                 expect(dizzy.determineArgs(mockFunctionString("class Test {\n    methodName(wrong) {\n        return wrong;\n    }\n}"))).toEqual([]);
+            });
+            it("understands objects with mixed functions", () => {
+                expect(dizzy.determineArgs(mockFunctionString("(config) => {\n    return { x: function (thing) { return [config,thing];}};\n}"))).toEqual([
+                    "config"
+                ]);
             });
         });
     });

--- a/spec/dizzy.spec.js
+++ b/spec/dizzy.spec.js
@@ -1,156 +1,27 @@
 "use strict";
 
-var dizzy = require("..");
-
-class es6Class {
-    deconstructor(wrong) {
-        return wrong;
-    }
-    constructor(right, correct) {
-        return right + correct;
-    }
-    reconstructor(incorrect) {
-        return incorrect;
-    }
-    subconstructor(wrong, bad) {
-        return wrong + bad;
-    }
-}
-
-function mockFunctionString(expectedString) {
-    var result;
-
-    result = new Function();
-    result.toString = () => {
-        return expectedString;
-    };
-
-    return result;
-}
-
-describe("Dizzy's exports", () => {
-    it("is an object", () => {
-        expect(typeof dizzy).toBe("object");
-    });
-    it("has .container()", () => {
-        expect(typeof dizzy.container).toBe("function");
-    });
-    describe("determineArgs()", () => {
-        it("is a function", () => {
-            expect(typeof dizzy.determineArgs).toBe("function");
-        });
-        describe("with actual objects", () => {
-            it("parses a normal function with no arguments", () => {
-                expect(dizzy.determineArgs(function f() {
-                    return true;
-                })).toEqual([]);
-            });
-            it("parses a normal function with three arguments", () => {
-                expect(dizzy.determineArgs(function f(dk, lmn, moose) {
-                    return dk + lmn + moose;
-                })).toEqual([
-                    "dk",
-                    "lmn",
-                    "moose"
-                ]);
-            });
-            it("parses an arrow function with one argument", () => {
-                expect(dizzy.determineArgs((test) => {
-                    return test;
-                })).toEqual([
-                    "test"
-                ]);
-            });
-            it("works with old classes", () => {
-                function oldClass(left, right) {
-                    return 3 * right == left;
-                }
-
-                expect(dizzy.determineArgs(oldClass)).toEqual([
-                    "left",
-                    "right"
-                ]);
-            });
-            it("works with new classes", () => {
-                expect(dizzy.determineArgs(es6Class)).toEqual([
-                    "right",
-                    "correct"
-                ]);
-            });
-            it("works with new class methods that have a single argument", () => {
-                var x;
-
-                x = new es6Class();
-                expect(dizzy.determineArgs(x.reconstructor)).toEqual([
-                    "incorrect"
-                ]);
-            });
-            it("works with new class methods that have multiple arguments", () => {
-                var x;
-
-                x = new es6Class();
-                expect(dizzy.determineArgs(x.subconstructor)).toEqual([
-                    "wrong",
-                    "bad"
-                ]);
-            });
-        });
-        describe("with mocked results", () => {
-            it("parses a condensed function with one argument", () => {
-                expect(dizzy.determineArgs(mockFunctionString("function(a){"))).toEqual([
-                    "a"
-                ]);
-            });
-            it("parses a terrible function with two arguments", () => {
-                expect(dizzy.determineArgs(mockFunctionString("\n  function \n\t somename \n\t ( \n\t mouse \n\t , \n\t cat \n\t ) \n\t {"))).toEqual([
-                    "mouse",
-                    "cat"
-                ]);
-            });
-            it("parses condensed arrow functions", () => {
-                expect(dizzy.determineArgs(mockFunctionString("(x,y)=>{"))).toEqual([
-                    "x",
-                    "y"
-                ]);
-            });
-            it("parses condensed arrow functions with no parenthesis", () => {
-                expect(dizzy.determineArgs(mockFunctionString("x=>{"))).toEqual([
-                    "x"
-                ]);
-            });
-            it("parses condensed arrow functions with no parenthesis and no parameters", () => {
-                expect(dizzy.determineArgs(mockFunctionString("_=>{"))).toEqual([]);
-            });
-            it("handles ES6 classes without a constructor", () => {
-                expect(dizzy.determineArgs(mockFunctionString("class Test {\n    methodName(wrong) {\n        return wrong;\n    }\n}"))).toEqual([]);
-            });
-            it("understands objects with mixed functions", () => {
-                expect(dizzy.determineArgs(mockFunctionString("(config) => {\n    return { x: function (thing) { return [config,thing];}};\n}"))).toEqual([
-                    "config"
-                ]);
-            });
-        });
-    });
-});
 describe("Dizzy", () => {
-    var instance;
+    var dizzy;
 
     beforeEach(() => {
-        instance = dizzy.container();
+        var Dizzy;
+
+        Dizzy = require("..");
+        dizzy = new Dizzy();
     });
     it("instantiates", () => {
-        expect(typeof instance).toBe("object");
+        expect(typeof dizzy).toBe("object");
     });
     describe("call()", () => {
         beforeEach(() => {
-            instance.provide("one", 1);
-            instance.provide("two", 2);
+            dizzy.register("one", 1);
+            dizzy.register("two", 2);
         });
         it("resolves arguments", () => {
             var args;
 
             args = null;
-            instance.call((one, two) => {
+            dizzy.call((one, two) => {
                 args = [
                     one,
                     two
@@ -165,21 +36,21 @@ describe("Dizzy", () => {
             var args;
 
             args = null;
-            instance.call([
-                "one"
-            ], (one, two) => {
+            dizzy.call((one, two) => {
                 args = [
                     one,
                     two
                 ];
-            });
+            }, [
+                "two"
+            ]);
             expect(args).toEqual([
-                1,
+                2,
                 undefined
             ]);
         });
         it("returns the function's result", () => {
-            expect(instance.call(() => {
+            expect(dizzy.call(() => {
                 return 15;
             })).toBe(15);
         });
@@ -187,7 +58,7 @@ describe("Dizzy", () => {
             var context;
 
             context = {};
-            instance.call(function () {
+            dizzy.call(function () {
                 this.worked = true;
             }, context);
             expect(context).toEqual({
@@ -197,132 +68,104 @@ describe("Dizzy", () => {
     });
     describe("instance()", () => {
         beforeEach(() => {
-            instance.provide("color", "red");
+            dizzy.register("one", 1);
+            dizzy.register("two", 2);
         });
-        it("makes different instances", () => {
-            var a, b;
+        it("resolves arguments", () => {
+            var args;
 
-            instance.instance("fakeClass", function () {
-                this.fakeClass = true;
-            });
-            a = instance.resolve("fakeClass");
-            b = instance.resolve("fakeClass");
-            expect(a).not.toBe(b);
+            args = null;
+            class TestClass {
+                constructor(one, two) {
+                    args = [
+                        one,
+                        two
+                    ];
+                }
+            }
+            dizzy.instance(TestClass);
+            expect(args).toEqual([
+                1,
+                2
+            ]);
         });
-        it("provides arguments automatically", () => {
-            var colorSaved, result;
+        it("works with argsArray", () => {
+            var args;
 
-            colorSaved = null;
-            instance.instance("fakeClass", function (color) {
-                colorSaved = color;
-                this.color = color;
-            });
-            result = instance.resolve("fakeClass");
-            expect(colorSaved).toBe("red");
-            expect(result.color).toBe("red");
+            args = null;
+            class TestClass {
+                constructor(one, two) {
+                    args = [
+                        one,
+                        two
+                    ];
+                }
+            }
+            dizzy.instance(TestClass, [
+                "two"
+            ]);
+            expect(args).toEqual([
+                2,
+                undefined
+            ]);
         });
-        it("provides arguments from a list", () => {
-            var colorSaved;
-
-            colorSaved = null;
-            instance.instance("fakeClass", [
-                "color"
-            ], function (something) {
-                colorSaved = something;
-            });
-            instance.resolve("fakeClass");
-            expect(colorSaved).toBe("red");
+        it("returns the instantiated object", () => {
+            class TestClass {}
+            expect(dizzy.instance(TestClass)).toEqual(jasmine.any(TestClass));
         });
     });
     describe("isRegistered()", () => {
         beforeEach(() => {
-            instance.provide("something", "pencil");
+            dizzy.register("something", "pencil");
         });
         it("finds something", () => {
-            expect(instance.isRegistered("something")).toBe(true);
+            expect(dizzy.isRegistered("something")).toBe(true);
         });
         it("notices missing things", () => {
-            expect(instance.isRegistered("things")).toBe(false);
+            expect(dizzy.isRegistered("things")).toBe(false);
         });
     });
     describe("list()", () => {
         it("can provide an empty list", () => {
-            expect(instance.list()).toEqual([]);
+            expect(dizzy.list()).toEqual([]);
         });
         it("can have items in the list", () => {
             var list;
 
-            instance.provide("x", "x");
-            instance.provide(7, 7);
-            list = instance.list();
+            dizzy.register("x", "x");
+            dizzy.register(7, 7);
+            list = dizzy.list();
             expect(list).toContain("x");
             expect(list).toContain(7);
             expect(list.length).toBe(2);
         });
     });
-    describe("provide()", () => {
-        it("provides numbers", () => {
-            instance.provide("test", 123);
-            expect(instance.resolve("test")).toBe(123);
-        });
-        it("provides objects", () => {
-            instance.provide("test", {
-                duck: true
-            });
-            expect(instance.resolve("test")).toEqual({
-                duck: true
+    describe("register()", () => {
+        [
+            "asFactory",
+            "asInstance",
+            "asValue",
+            "cached",
+            "fromContainer",
+            "fromModule",
+            "fromValue",
+            "withContext"
+        ].forEach((methodName) => {
+            it("returns something with method: " + methodName, () => {
+                var provider;
+
+                provider = dizzy.register("x", "y");
+                expect(provider[methodName]).toEqual(jasmine.any(Function));
             });
         });
     });
-    // register() is tested through the helper methods.
-    // Tests should be added here if there are any code paths that
-    // do not get tested through other means.
     describe("resolve()", () => {
         // Only testing failure paths here because normal usage
         // is tested through other methods already.
         it("throws when a key is not defined", () => {
             expect(() => {
-                instance.resolve("not defined");
+                dizzy.resolve("not defined");
             }).toThrow();
-        });
-    });
-    describe("singleton()", () => {
-        beforeEach(() => {
-            instance.provide("color", "blue");
-        });
-        it("makes only one instance", () => {
-            var a, b;
-
-            instance.singleton("fakeClass", function () {
-                this.fakeClass = true;
-            });
-            a = instance.resolve("fakeClass");
-            b = instance.resolve("fakeClass");
-            expect(a).toBe(b);
-        });
-        it("provides arguments automatically", () => {
-            var colorSaved, result;
-
-            colorSaved = null;
-            instance.singleton("fakeClass", function (color) {
-                colorSaved = color;
-                this.color = color;
-            });
-            result = instance.resolve("fakeClass");
-            expect(colorSaved).toBe("blue");
-            expect(result.color).toBe("blue");
-        });
-        it("provides arguments from a list", () => {
-            var colorSaved;
-
-            colorSaved = null;
-            instance.singleton("fakeClass", [
-                "color"
-            ], function (something) {
-                colorSaved = something;
-            });
-            instance.resolve("fakeClass");
-            expect(colorSaved).toBe("blue");
         });
     });
 });

--- a/spec/util.spec.js
+++ b/spec/util.spec.js
@@ -1,0 +1,131 @@
+"use strict";
+
+class es6Class {
+    deconstructor(wrong) {
+        return wrong;
+    }
+    constructor(right, correct) {
+        return right + correct;
+    }
+    reconstructor(incorrect) {
+        return incorrect;
+    }
+    subconstructor(wrong, bad) {
+        return wrong + bad;
+    }
+}
+
+function mockFunctionString(expectedString) {
+    var result;
+
+    result = new Function();
+    result.toString = () => {
+        return expectedString;
+    };
+
+    return result;
+}
+
+describe("util", () => {
+    var util;
+
+    beforeEach(() => {
+        util = require("../lib/util");
+    });
+    describe("determineArgs()", () => {
+        it("is a function", () => {
+            expect(typeof util.determineArgs).toBe("function");
+        });
+        describe("with actual objects", () => {
+            it("parses a normal function with no arguments", () => {
+                expect(util.determineArgs(function f() {
+                    return true;
+                })).toEqual([]);
+            });
+            it("parses a normal function with three arguments", () => {
+                expect(util.determineArgs(function f(dk, lmn, moose) {
+                    return dk + lmn + moose;
+                })).toEqual([
+                    "dk",
+                    "lmn",
+                    "moose"
+                ]);
+            });
+            it("parses an arrow function with one argument", () => {
+                expect(util.determineArgs((test) => {
+                    return test;
+                })).toEqual([
+                    "test"
+                ]);
+            });
+            it("works with old classes", () => {
+                function oldClass(left, right) {
+                    return 3 * right == left;
+                }
+
+                expect(util.determineArgs(oldClass)).toEqual([
+                    "left",
+                    "right"
+                ]);
+            });
+            it("works with new classes", () => {
+                expect(util.determineArgs(es6Class)).toEqual([
+                    "right",
+                    "correct"
+                ]);
+            });
+            it("works with new class methods that have a single argument", () => {
+                var x;
+
+                x = new es6Class();
+                expect(util.determineArgs(x.reconstructor)).toEqual([
+                    "incorrect"
+                ]);
+            });
+            it("works with new class methods that have multiple arguments", () => {
+                var x;
+
+                x = new es6Class();
+                expect(util.determineArgs(x.subconstructor)).toEqual([
+                    "wrong",
+                    "bad"
+                ]);
+            });
+        });
+        describe("with mocked results", () => {
+            it("parses a condensed function with one argument", () => {
+                expect(util.determineArgs(mockFunctionString("function(a){"))).toEqual([
+                    "a"
+                ]);
+            });
+            it("parses a terrible function with two arguments", () => {
+                expect(util.determineArgs(mockFunctionString("\n  function \n\t somename \n\t ( \n\t mouse \n\t , \n\t cat \n\t ) \n\t {"))).toEqual([
+                    "mouse",
+                    "cat"
+                ]);
+            });
+            it("parses condensed arrow functions", () => {
+                expect(util.determineArgs(mockFunctionString("(x,y)=>{"))).toEqual([
+                    "x",
+                    "y"
+                ]);
+            });
+            it("parses condensed arrow functions with no parenthesis", () => {
+                expect(util.determineArgs(mockFunctionString("x=>{"))).toEqual([
+                    "x"
+                ]);
+            });
+            it("parses condensed arrow functions with no parenthesis and no parameters", () => {
+                expect(util.determineArgs(mockFunctionString("_=>{"))).toEqual([]);
+            });
+            it("handles ES6 classes without a constructor", () => {
+                expect(util.determineArgs(mockFunctionString("class Test {\n    methodName(wrong) {\n        return wrong;\n    }\n}"))).toEqual([]);
+            });
+            it("understands objects with mixed functions", () => {
+                expect(util.determineArgs(mockFunctionString("(config) => {\n    return { x: function (thing) { return [config,thing];}};\n}"))).toEqual([
+                    "config"
+                ]);
+            });
+        });
+    });
+});


### PR DESCRIPTION
This allows for a more intuitive fluent interface and far more flexibility for deciding
- the source of the value
- how the value is handled internally
- additional things that should happen (like options)

dizzy.register(key, value) returns a DizzyProvider object.  The provider has methods to determine the source (fromContainer, fromModule, fromValue) and how to handle the value (asFactory, asInstance, asValue).  It can even cache or set context (cached, withContext).

Examples:

```
dizzy.register("Thing", class Thing {]);
dizzy.register("thingSingleton", "Thing").fromContainer().asInstance().cached()
dizzy.register("fs", "fs").fromModule();
dizzy.register("factory", function (...) {...}).asFactory().withContext(someObject);
```

@AbsentSemicolon Would you review these changes?
